### PR TITLE
Fixing system language not changing back after closing a game

### DIFF
--- a/UWPHook.sln
+++ b/UWPHook.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 15.0.27703.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UWPHook", "UWPHook\UWPHook.csproj", "{AFE09BCF-28A4-48EE-876B-FEF080D04D5F}"
 EndProject
-Project("{840C416C-B8F3-42BC-B0DD-F6BB14C9F8CB}") = "Setup", "Setup\Setup.aiproj", "{F63C6051-9812-47BE-87F2-ECA8F2E89EC0}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,12 +18,6 @@ Global
 		{AFE09BCF-28A4-48EE-876B-FEF080D04D5F}.DefaultBuild|Any CPU.Build.0 = Debug|Any CPU
 		{AFE09BCF-28A4-48EE-876B-FEF080D04D5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AFE09BCF-28A4-48EE-876B-FEF080D04D5F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F63C6051-9812-47BE-87F2-ECA8F2E89EC0}.Debug|Any CPU.ActiveCfg = DefaultBuild
-		{F63C6051-9812-47BE-87F2-ECA8F2E89EC0}.Debug|Any CPU.Build.0 = DefaultBuild
-		{F63C6051-9812-47BE-87F2-ECA8F2E89EC0}.DefaultBuild|Any CPU.ActiveCfg = DefaultBuild
-		{F63C6051-9812-47BE-87F2-ECA8F2E89EC0}.DefaultBuild|Any CPU.Build.0 = DefaultBuild
-		{F63C6051-9812-47BE-87F2-ECA8F2E89EC0}.Release|Any CPU.ActiveCfg = DefaultBuild
-		{F63C6051-9812-47BE-87F2-ECA8F2E89EC0}.Release|Any CPU.Build.0 = DefaultBuild
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UWPHook/GamesWindow.xaml.cs
+++ b/UWPHook/GamesWindow.xaml.cs
@@ -96,7 +96,7 @@ namespace UWPHook
             {
                 if (Properties.Settings.Default.ChangeLanguage && !String.IsNullOrEmpty(Properties.Settings.Default.TargetLanguage))
                 {
-                    ScriptManager.RunScript("Set - WinUILanguageOverride " + currentLanguage);
+                    ScriptManager.RunScript("Set-WinUILanguageOverride " + currentLanguage);
                 }
 
                 //The user has probably finished using the app, so let's close UWPHook to keep the experience clean 


### PR DESCRIPTION
There's a [bug](https://github.com/BrianLima/UWPHook/issues/3#issuecomment-253202230) reported in #3 that I noticed still happens,  that caused the display language to not change back to it's original value after closing a game. Turns out it was just a typo in the powershell command. 

Instead of `Set-WinUILanguageOverride pt-BR`, UWP would call `Set - WinUILanguageOverride pt-BR` (notice the extra spaces around `-`).