### PR TITLE
Display error when SteamGridDB request fails with 401

### DIFF
--- a/UWPHook/GamesWindow.xaml.cs
+++ b/UWPHook/GamesWindow.xaml.cs
@@ -3,6 +3,7 @@ using SharpSteam;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Globalization;

--- a/UWPHook/GamesWindow.xaml.cs
+++ b/UWPHook/GamesWindow.xaml.cs
@@ -200,10 +200,11 @@ namespace UWPHook
             string tmpGridDirectory = Path.GetTempPath() + "UWPHook\\tmp_grid\\";
 
             var games = await api.SearchGame(appName);
-
+            
             if (games != null)
             {
                 var game = games[0];
+                Debug.WriteLine("Detected Game: " + game.ToString());
                 UInt64 gameId = GenerateSteamGridAppId(appName, appTarget);
 
                 if (!Directory.Exists(tmpGridDirectory))
@@ -215,6 +216,8 @@ namespace UWPHook
                 var gameGridsHorizontal = api.GetGameGrids(game.Id, "460x215,920x430");
                 var gameHeroes = api.GetGameHeroes(game.Id);
                 var gameLogos = api.GetGameLogos(game.Id);
+
+                Debug.WriteLine("Game ID: " + game.Id);
 
                 await Task.WhenAll(
                     gameGridsVertical,
@@ -272,14 +275,16 @@ namespace UWPHook
 
                 List<Task> gridImagesDownloadTasks = new List<Task>();
                 bool downloadGridImages = !String.IsNullOrEmpty(Properties.Settings.Default.SteamGridDbApiKey);
-
                 //To make things faster, decide icons and download grid images before looping users
+                Debug.WriteLine("downloadGridImages: " + (downloadGridImages));
+
                 foreach (var app in selected_apps)
                 {
                     app.Icon = app.widestSquareIcon();
 
                     if (downloadGridImages)
                     {
+                        Debug.WriteLine("Downloading grid images for app " + app.Name);
                         gridImagesDownloadTasks.Add(DownloadTempGridImages(app.Name, exePath));
                     }
                 }

--- a/UWPHook/SettingsWindow.xaml
+++ b/UWPHook/SettingsWindow.xaml
@@ -24,7 +24,7 @@
         </Grid.RowDefinitions>
         <materialDesign:ColorZone Padding="16" materialDesign:ShadowAssist.ShadowDepth="Depth2" Mode="PrimaryMid" VerticalAlignment="Top" Height="80" Grid.ColumnSpan="2" Margin="0,0,-0.4,0"/>
         <Image x:Name="image" HorizontalAlignment="Left" Width="178" Height="80" VerticalAlignment="Top" Source="Resources/WhiteTransparent.png" Stretch="UniformToFill" ToolTip="Welcome to UWPHook, add your UWP apps and games to Steam!"/>
-        <Grid Margin="10,9.4,10.2,10.2" Grid.Row="1">
+        <Grid Margin="10,88,10,44" Grid.RowSpan="2">
             <Grid.RowDefinitions>
                 <RowDefinition Height="62"/>
                 <RowDefinition Height="40"/>
@@ -53,13 +53,13 @@
             <ToggleButton x:Name="streaming_toggle" Style="{StaticResource MaterialDesignSwitchToggleButton}" VerticalAlignment="Top" Margin="6,6,0,0" ToolTip="MaterialDesignSwitchToggleButton" IsChecked="False" Height="18" HorizontalAlignment="Left" Width="46" Grid.Row="2" />
             <Label ToolTip="This fixes Steam in-home Streaming, set this in the host computer." x:Name="label1_Copy" Content="Enable streaming mode" Margin="5,1,0,0" VerticalAlignment="Top" Height="29" Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="2"/>
             <Label ToolTip="SteamGridDB API key used to download Steam's library artwork. Leave it blank if you don't want to download artwork." x:Name="label1_Copy1" Content="Api Key" Margin="5,39,0,0" VerticalAlignment="Top" Height="29" Grid.Row="3" Grid.Column="1"/>
-            <TextBox x:Name="steamgriddb_api_key" Grid.Column="2" Height="29" Margin="5,39,10,0" Grid.Row="3" TextWrapping="Wrap" VerticalAlignment="Top" Grid.ColumnSpan="2"/>
+            <TextBox x:Name="steamgriddb_api_key" Grid.Column="1" Height="29" Margin="150,39,10,0" Grid.Row="3" TextWrapping="Wrap" VerticalAlignment="Top" Grid.ColumnSpan="3"/>
             <materialDesign:ColorZone Padding="16" materialDesign:ShadowAssist.ShadowDepth="Depth2" Mode="PrimaryMid" VerticalAlignment="Top" Height="27" Grid.ColumnSpan="4" Margin="0,7,0,0" Grid.Row="3">
                 <Label Content="SteamGrid" HorizontalAlignment="Left" Margin="-10,-15,0,-17" FontFamily="Segoe UI Semibold" FontSize="14" Foreground="#DDFFFFFF"/>
             </materialDesign:ColorZone>
             <Button x:Name="key_Button" Content="{materialDesign:PackIcon Key}" ToolTip="Get a new API Key" Margin="6,39,7,147" Grid.Row="3" Height="Auto" Click="key_Button_Click" />
             <Label ToolTip="The main style of the artwork." x:Name="label1_Copy2" Content="Artwork Style" Margin="5,73,0,0" VerticalAlignment="Top" Height="29" Grid.Row="3" Grid.Column="1"/>
-            <ComboBox x:Name="style_comboBox" Margin="0,73,10,0" VerticalAlignment="Top" Height="31" Grid.Column="2" HorizontalAlignment="Right" Width="222" Grid.Row="3" Grid.ColumnSpan="2">
+            <ComboBox x:Name="style_comboBox" Margin="0,73,10,0" VerticalAlignment="Top" Height="31" Grid.Column="1" HorizontalAlignment="Right" Width="244" Grid.Row="3" Grid.ColumnSpan="3">
                 <ComboBoxItem Content="Any"/>
                 <ComboBoxItem Content="Alternate"/>
                 <ComboBoxItem Content="Blurred"/>
@@ -68,27 +68,27 @@
                 <ComboBoxItem Content="No Logo"/>
             </ComboBox>
             <Label ToolTip="Type of the artwork, animated, static or both." x:Name="label1_Copy3" Content="Artwork Type" Margin="5,109,0,0" VerticalAlignment="Top" Height="29" Grid.Row="3" Grid.Column="1"/>
-            <ComboBox x:Name="type_comboBox" Margin="0,109,10,0" VerticalAlignment="Top" Height="31" Grid.Column="2" HorizontalAlignment="Right" Width="222" Grid.Row="3" Grid.ColumnSpan="2">
+            <ComboBox x:Name="type_comboBox" Margin="0,109,10,0" VerticalAlignment="Top" Height="31" Grid.Column="1" HorizontalAlignment="Right" Width="244" Grid.Row="3" Grid.ColumnSpan="3">
                 <ComboBoxItem Content="Any"/>
                 <ComboBoxItem Content="Static"/>
                 <ComboBoxItem Content="Animated"/>
             </ComboBox>
             <Label ToolTip="Consider NSFW artwork?" x:Name="label1_Copy4" Content="Artwork nsfw" Margin="5,142,0,0" VerticalAlignment="Top" Height="29" Grid.Row="3" Grid.Column="1"/>
-            <ComboBox x:Name="nfsw_comboBox" Margin="0,145,10,0" VerticalAlignment="Top" Height="31" Grid.Column="2" HorizontalAlignment="Right" Width="222" Grid.Row="3" Grid.ColumnSpan="2">
+            <ComboBox x:Name="nfsw_comboBox" Margin="0,145,10,0" VerticalAlignment="Top" Height="31" Grid.Column="1" HorizontalAlignment="Right" Width="244" Grid.Row="3" Grid.ColumnSpan="3">
                 <ComboBoxItem Content="No"/>
                 <ComboBoxItem Content="Any"/>
                 <ComboBoxItem Content="Yes"/>
             </ComboBox>
             <Label ToolTip="Consider meme and humorous artwork?" x:Name="label1_Copy5" Content="Artwork humorous" Margin="5,176,0,0" VerticalAlignment="Top" Height="29" Grid.Row="3" Grid.Column="1"/>
-            <ComboBox x:Name="humor_comboBox" Margin="0,181,10,0" VerticalAlignment="Top" Height="31" Grid.Column="2" HorizontalAlignment="Right" Width="222" Grid.Row="3" Grid.ColumnSpan="2">
+            <ComboBox x:Name="humor_comboBox" Margin="0,181,10,0" VerticalAlignment="Top" Height="31" Grid.Column="1" HorizontalAlignment="Right" Width="244" Grid.Row="3" Grid.ColumnSpan="3">
                 <ComboBoxItem Content="No"/>
                 <ComboBoxItem Content="Any"/>
                 <ComboBoxItem Content="Yes"/>
             </ComboBox>
             <Label ToolTip="Add these tags to exported games, use comma separated values" x:Name="label1_Copy6" Content="Export with these tags" Margin="5,35,8,0" VerticalAlignment="Top" Height="29" Grid.Column="1" Grid.Row="2"/>
-            <TextBox x:Name="tags_textBox" Grid.Column="2" Height="29" Margin="5,35,10,0" Grid.Row="2" TextWrapping="Wrap" VerticalAlignment="Top" Grid.ColumnSpan="2"/>
+            <TextBox x:Name="tags_textBox" Grid.Column="1" Height="29" Margin="150,35,10,0" Grid.Row="2" TextWrapping="Wrap" VerticalAlignment="Top" Grid.ColumnSpan="3"/>
         </Grid>
-        <Grid Margin="10,9,9,1" Grid.Column="1" Grid.Row="1">
+        <Grid Margin="10,88,9,35" Grid.Column="1" Grid.RowSpan="2">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="63*"/>
                 <ColumnDefinition Width="164*"/>

--- a/UWPHook/SettingsWindow.xaml.cs
+++ b/UWPHook/SettingsWindow.xaml.cs
@@ -46,7 +46,7 @@ namespace UWPHook
             Properties.Settings.Default.TargetLanguage = cultures_comboBox.SelectedItem.ToString();
             Properties.Settings.Default.Seconds = Int32.Parse(seconds_comboBox.SelectedItem.ToString().Substring(0, 1));
             Properties.Settings.Default.StreamMode = (bool)streaming_toggle.IsChecked;
-            Properties.Settings.Default.SteamGridDbApiKey = steamgriddb_api_key.Text;
+            Properties.Settings.Default.SteamGridDbApiKey = steamgriddb_api_key.Text.Trim('\r', '\n');
             Properties.Settings.Default.SelectedSteamGridDB_Style = style_comboBox.SelectedIndex;
             Properties.Settings.Default.SelectedSteamGridDB_Type = type_comboBox.SelectedIndex;
             Properties.Settings.Default.SelectedSteamGridDB_nfsw = nfsw_comboBox.SelectedIndex;
@@ -90,7 +90,7 @@ namespace UWPHook
         {
             MessageBox.Show(messageBoxText: "You are being redirected to SteamGridDB website!\r\n" +
                 "Log-in, or create your account, go to your profile preferences and click 'Generate API Key', then paste the key back on UWPHook.", "Attention!", MessageBoxButton.OK, MessageBoxImage.Information );
-            System.Diagnostics.Process.Start("https://www.steamgriddb.com/profile/preferences");
+            System.Diagnostics.Process.Start("https://www.steamgriddb.com/profile/preferences/api");
         }
     }
 }

--- a/UWPHook/SteamGridDb/SteamGridDbApi.cs
+++ b/UWPHook/SteamGridDb/SteamGridDbApi.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using UWPHook.Properties;
+using System.Diagnostics;
 
 namespace UWPHook.SteamGridDb
 {
@@ -36,9 +37,17 @@ namespace UWPHook.SteamGridDb
 
             GameResponse[] games = null;
             HttpResponseMessage response = await httpClient.GetAsync(path);
-
+            
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            {
+                System.Windows.MessageBox.Show("Warning: SteamGrid API Key Invalid. Please either remove the API key in settings or enter a valid API key.");
+                Debug.WriteLine("ERROR RESPONSE: " + response.ToString());
+                SettingsWindow window = new SettingsWindow();
+                window.ShowDialog();
+            }
             if (response.IsSuccessStatusCode)
             {
+                
                 var parsedResponse = await response.Content.ReadAsAsync<ResponseWrapper<GameResponse>>();
                 games = parsedResponse.Data;
             }


### PR DESCRIPTION
This PR allows for catching 401 error conditions with SteamGridDB's REST calls instead of silently failing. It also slightly extends the text field for the API key to prevent text wrapping, in addition to trimming any stray spaces. 