### PR TITLE
Add two methods to get target executable + get icon from image api

### DIFF
--- a/UWPHook/GamesWindow.xaml.cs
+++ b/UWPHook/GamesWindow.xaml.cs
@@ -398,7 +398,29 @@ namespace UWPHook
                         {
                             foreach (var app in selected_apps)
                             {
-                                string icon = PersistAppIcon(app);
+                                string icon = "";
+                                if (gridImagesDownloadTasks.Count > 0)
+                                {
+                                    await Task.WhenAll(gridImagesDownloadTasks);
+
+                                    await Task.Run(() =>
+                                    {
+                                        string tmpGridDirectory = Path.GetTempPath() + "UWPHook\\tmp_grid\\";
+                                        string[] images = Directory.GetFiles(tmpGridDirectory);
+
+                                        foreach (string image in images)
+                                        {
+                                            if (image.EndsWith("_logo.png"))
+                                            {
+                                                icon = PersistAppIcon(app, image);
+                                                break;
+                                            }
+                                        }
+                                    });
+                                }
+                                else {
+                                    icon = PersistAppIcon(app);
+                                }
 
                                 VDFEntry newApp = new VDFEntry()
                                 {
@@ -489,15 +511,31 @@ namespace UWPHook
         private string PersistAppIcon(AppEntry app)
         {
             string path = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            string icons_path = path + @"\\Briano\\UWPHook\\icons\\";
+            string icons_path = path + @"\Briano\UWPHook\icons\";
 
             if (!Directory.Exists(icons_path))
             {
                 Directory.CreateDirectory(icons_path);
             }
 
-            string destFile = String.Join(String.Empty, icons_path+ @"\\", app.Aumid + Path.GetFileName(app.Icon));
+            string destFile = String.Join(String.Empty, icons_path, app.Aumid + Path.GetFileName(app.Icon));
             File.Copy(app.Icon, destFile, true);
+
+            return destFile;
+        }
+
+        private string PersistAppIcon(AppEntry app, string iconDownloadedPath)
+        {
+            string path = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string icons_path = path + @"\Briano\UWPHook\icons\";
+
+            if (!Directory.Exists(icons_path))
+            {
+                Directory.CreateDirectory(icons_path);
+            }
+
+            string destFile = String.Join(String.Empty, icons_path, app.Aumid + Path.GetFileName(iconDownloadedPath));
+            File.Copy(iconDownloadedPath, destFile, true);
 
             return destFile;
         }

--- a/UWPHook/Resources/GetAUMIDScript.ps1
+++ b/UWPHook/Resources/GetAUMIDScript.ps1
@@ -10,24 +10,46 @@ foreach ($app in $installedapps)
             {
                     $appx = Get-AppxPackageManifest $app;
                     $name = $appx.Package.Properties.DisplayName;
-                    $executable = (Select-Xml -Path ($app.InstallLocation + "\MicrosoftGame.Config") -XPath "/Game/ExecutableList/Executable/@Name").Node.Value
+                    $executable = $appx.Package.Applications.Application.Executable;
+
+                    # Handle app running with microsoft launcher or which doesn't have an executable in the manifest
+                    if([string]::IsNullOrWhitespace($executable) -or $executable -eq "GameLaunchHelper.exe") {
+                        if(Test-Path -Path ($app.InstallLocation + "\MicrosoftGame.Config")) {
+                            [xml]$msconfig = Get-Content ($app.InstallLocation + "\MicrosoftGame.Config");
+                            $executable = $msconfig.Game.ExecutableList.Executable.Name;
+                        }
+                        else {
+                            # Cannot handle app which doesn't have any configuration to read
+                            continue;
+                        }
+                    }
                     # Convert object to ensure is the String of execuble (cf Halo Master Chief Collection example below)
                     # mcclauncher.exe
                     # MCC\Binaries\Win64\MCCWinStore-Win64-Shipping.exe
                     if($executable -is [Object[]]) { $executable = $executable[1].ToString() }
 
+                    # Exclude apps without a name acceptable
                     if($name -like '*DisplayName*' -or $name  -like '*ms-resource*')
                     {
-                        $name = $appx.Package.Applications.Application.VisualElements.DisplayName;
-                    }
-                    if($name -like '*DisplayName*' -or $name  -like '*ms-resource*')
-                    {
-                        $name = "App name not found, double click here to edit it";
+                        continue;
                     }
 
                     $logo = $app.InstallLocation + "\" + $appx.Package.Applications.Application.VisualElements.Square150x150Logo;
+                    
+                    # Check for possible duplicate game like Halo MCC which have two version (one with AC and one witohut AC)
+                    $duplicate = $false;
+                    foreach($item in $aumidList) {
+                        #Write-host $item - $name
+                        if($item.StartsWith($name)) {
+                            $duplicate = $true;
+                            break;
+                        }
+                    }
 
-                    $aumidList += $name + "|" + $logo + "|" + $app.packagefamilyname + "!" + $id + "|" + $executable + ";"
+                    # Insert if not duplicated
+                    if(!$duplicate) {
+                        $aumidList += $name + "|" + $logo + "|" + $app.packagefamilyname + "!" + $id + "|" + $executable + ";"
+                    }
                 }
             }
         }


### PR DESCRIPTION
Add a new way to handle application exe :
-  via appxmanifest
- via gameconfig if exe not found in appxmanifest or equals GameLaunchHelper.exe. 
- exclude apps which doesn't have name or like ms-resource. Seems basic apps of microsoft and not needed
- Avoid duplicated apps like Halo MCC which have two exe (one with anticheat, one without. Get the first one which is with AC)

Get logo from api to construct the icon for steam manifest if available due to some games which have their assets encrypted and it seems not possible to copy files due of this option. (CF: Frostpunk & Halo Wars)