### PR TITLE
Add support for jpg icons; only replace shortcuts where added by UWPHook

### DIFF
--- a/UWPHook/AppEntry.cs
+++ b/UWPHook/AppEntry.cs
@@ -87,8 +87,11 @@ namespace UWPHook
 
             try
             {
-                //Get every png in this directory, Steam only allows for .png's
+                //Get every png/jpg/jpeg in this directory
+                //Steam only allows for .png's in the drop-down, but jpgs work too
                 images.AddRange(Directory.GetFiles(_icon_path, "*.png"));
+                images.AddRange(Directory.GetFiles(_icon_path, "*.jpg"));
+                images.AddRange(Directory.GetFiles(_icon_path, "*.jpeg"));
             }
             catch (DirectoryNotFoundException)
             {

--- a/UWPHook/GamesWindow.xaml.cs
+++ b/UWPHook/GamesWindow.xaml.cs
@@ -459,9 +459,8 @@ namespace UWPHook
                                 for (int i = 0; i < shortcuts.Length; i++)
                                 {
                                     Log.Verbose(shortcuts[i].ToString());
-
-
-                                    if (shortcuts[i].AppName == app.Name)
+                                    //only catch UWPHook entries
+                                    if (shortcuts[i].AppName == app.Name && shortcuts[i].Exe == exePath)
                                     {
                                         isFound = true;
                                         Log.Verbose(app.Name + " already added to Steam. Updating existing shortcut.");


### PR DESCRIPTION
Icons: Steam does support JPG images, it just doesn't expose them as an option in its own finder for selecting an icon for a shortcut. Fixes XGP game ReCore, which only has one, non-square PNG asset; all other logos are JPG.

Shortcut maintenance: only replace a shortcut in the config.vdf where the name matches, and the EXE in the config.vdf is the UWPHook EXE being used to add the icon. This avoids cases where the same game may be installed in multiple ways; it also plays nicer with other launcher tools.