### PR TITLE
Create temp grid directory if it doesn't exist

### DIFF
--- a/UWPHook/GamesWindow.xaml.cs
+++ b/UWPHook/GamesWindow.xaml.cs
@@ -430,6 +430,12 @@ namespace UWPHook
                                     await Task.Run(() =>
                                     {
                                         string tmpGridDirectory = Path.GetTempPath() + "UWPHook\\tmp_grid\\";
+
+                                        if (!Directory.Exists(tmpGridDirectory))
+                                        {
+                                            Directory.CreateDirectory(tmpGridDirectory);
+                                        }
+
                                         string[] images = Directory.GetFiles(tmpGridDirectory);
 
                                         UInt64 gameId = GenerateSteamGridAppId(app.Name, exePath);


### PR DESCRIPTION
Fixes #109 

I had the same issue and went ahead and fixed it.