### PR TITLE
Fixed issue #141 Can't access games in Windows 11 pro 24h2

### DIFF
--- a/UWPHook/App.config
+++ b/UWPHook/App.config
@@ -103,6 +103,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
+	    <dependentAssembly>
+			<assemblyIdentity name="System.Security.Principal.Windows" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+			<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="5.0.0.0" />
+		</dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/UWPHook/UWPHook.csproj
+++ b/UWPHook/UWPHook.csproj
@@ -222,6 +222,12 @@
     <PackageReference Include="Serilog.Sinks.File">
       <Version>5.0.0</Version>
     </PackageReference>
+    <PackageReference Include="System.Memory">
+      <Version>4.6.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Security.Principal.Windows">
+      <Version>5.0.0</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Use nuget version of System.Security.Principal and add a binding redirect to fix version conflict